### PR TITLE
Localisation fixes

### DIFF
--- a/com/boobuilds/GearItem.as
+++ b/com/boobuilds/GearItem.as
@@ -127,12 +127,21 @@ class com.boobuilds.GearItem
 		if (tooltip.m_PrefixData != null)
 		{
 			var glyphStr:String = tooltip.m_PrefixData.m_Title;
-			if (glyphStr.lastIndexOf(Localisation.Glyph) == glyphStr.length - Localisation.Glyph.length)
+			if (Localisation.GetLocalisation() != "fr")
 			{
-				ret.m_Prefix = glyphStr;
+				if (glyphStr.lastIndexOf(Localisation.Glyph) == glyphStr.length - Localisation.Glyph.length)
+				{
+					ret.m_Prefix = glyphStr;
+				}
+			}
+			else
+			{
+				if (glyphStr.indexOf(Localisation.Glyph) == 0)
+				{
+					ret.m_Prefix = glyphStr;
+				}
 			}
 		}
-		
 		return new GearItem(ret.m_Name, ret.m_defaultPosition, ret.m_Prefix, ret.m_Suffix, ret.m_numPips, ret.m_iconPath);
 	}
 	

--- a/com/boobuilds/Localisation.as
+++ b/com/boobuilds/Localisation.as
@@ -46,7 +46,7 @@ class com.boobuilds.Localisation
 	private static var DeleteIconTooltipMisc_English:String = "";
 
 	// French
-	private static var Signet_French:String = "Sceau";
+	private static var Signet_French:String = "Insigne";
 	private static var Glyph_French:String = "Glyphe";
 	private static var Skills_French:String = "Compétences";
 	private static var Passives_French:String = "Passives";
@@ -61,7 +61,7 @@ class com.boobuilds.Localisation
 
 	// German
 	private static var Signet_German:String = "Siegel";
-	private static var Glyph_German:String = "Glyph";
+	private static var Glyph_German:String = "Glyphe";
 	private static var Skills_German:String = "Fähigkeiten";
 	private static var Passives_German:String = "Passives";
 	private static var Augments_German:String = "Augmente";
@@ -73,6 +73,11 @@ class com.boobuilds.Localisation
 	private static var DeleteIconTooltipDesc_German:String = "Wählen Sie diesen Knopf aus, um die ausgewählte Einzelheit zu klären";
 	private static var DeleteIconTooltipMisc_German:String = "";
 
+	public static function GetLocalisation():String
+	{
+		return LDBFormat.GetCurrentLanguageCode();
+	}
+	
 	public static function SetLocalisation():Void
 	{
 		var lang:String = LDBFormat.GetCurrentLanguageCode();


### PR DESCRIPTION
Issues with the localisation are preventing current release of boobuilds from storing glyph and signet data when using french or german localisation. 
```
EN : Radiant Ashes of Shriven Souls~31~Intricate Fierce Glyph~Signet of Shattering~
FR : Cendres radieuses des âmes absoutes~31~~~3~
```
With the item differentiating any newly created/updated build will therefore fail to find any matching items.

In french glyph name starts with the (localized) "glyph" string
```
Fr: Glyphe virulent complexe
En: Intricate Fierce Glyph
De: Komplexe vernichtende Glyphe
```
German localisation of `Glyph` should also be `Glyphe`

In french signet should be called `Insigne` instead of `Sceau`
`[Insigne de lacération]`

With these changes it seems to handle all languages (tested with 3 builds on each language,and i also had someone else test french for me).
It will however require updating all stored builds.
